### PR TITLE
By default prefer instanciation over cloning

### DIFF
--- a/src/Depend/Descriptor.php
+++ b/src/Depend/Descriptor.php
@@ -23,7 +23,7 @@ class Descriptor implements DescriptorInterface
     /**
      * @var boolean
      */
-    protected $isCloneable = true;
+    protected $isCloneable = false;
 
     /**
      * @var boolean


### PR DESCRIPTION
Cloning is no longer the default option for non-shared dependencies because of complication with development structures. Cloning requires additional logic that is not usually automatically built into classes unless explicitly needed.

If cloning is desired for non-shared dependencies this will now need to be set for each case.
