### PR TITLE
Inherit shareable and cloneable settings

### DIFF
--- a/src/Depend/Descriptor.php
+++ b/src/Depend/Descriptor.php
@@ -193,7 +193,28 @@ class Descriptor implements DescriptorInterface
      */
     public function isCloneable()
     {
-        return $this->isCloneable;
+        if (!$this->isCloneable) {
+            return false;
+        }
+
+        if ($this->parent && !$this->parent->isCloneable()) {
+            return false;
+        }
+
+        if (is_array($this->interfaces)) {
+            /** @var $interface Descriptor */
+            foreach ($this->interfaces as $interface) {
+                if ($interface->getName() === $this->getName()) {
+                    continue;
+                }
+
+                if (!$interface->isCloneable()) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -201,7 +222,28 @@ class Descriptor implements DescriptorInterface
      */
     public function isShared()
     {
-        return $this->isShared;
+        if (!$this->isShared) {
+            return false;
+        }
+
+        if ($this->parent && !$this->parent->isShared()) {
+            return false;
+        }
+
+        if (is_array($this->interfaces)) {
+            /** @var $interface Descriptor */
+            foreach ($this->interfaces as $interface) {
+                if ($interface->getName() === $this->getName()) {
+                    continue;
+                }
+
+                if (!$interface->isShared()) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
Fix issue where previously disabled sharing and cloning on parent classes was not inherited to subclasses. This fix is extended to flags set on interfaces whereby sharing and cloning can be disabled based on interface implementation as well as class extension.
